### PR TITLE
Updates to deal with environment drift and error output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION ?= "latest"
 INDEX_IMAGE = "quay.io/joelanford/example-operator-index:$(VERSION)"
 
-catalog: bin/opm veneer.yaml convert.sh
+catalog: bin/opm bin/yq veneer.yaml convert.sh
 	rm -rf catalog && mkdir catalog && ./convert.sh veneer.yaml > catalog/catalog.yaml
 
 .PHONY: sanity
@@ -10,7 +10,7 @@ sanity: catalog bin/opm
 	bin/opm validate catalog
 
 .PHONY: build
-build: catalog sanity bin/opm
+build: catalog sanity bin/opm bin/yq
 	bin/opm alpha generate dockerfile catalog
 	docker build -t $(INDEX_IMAGE) -f catalog.Dockerfile .
 	rm catalog.Dockerfile
@@ -34,3 +34,9 @@ OPM_VERSION=v1.19.5
 bin/opm:
 	mkdir -p bin
 	curl -sLO https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OS)-$(ARCH)-opm && chmod +x $(OS)-$(ARCH)-opm && mv $(OS)-$(ARCH)-opm bin/opm
+
+YQ_VERSION=v4.22.1
+YQ_BINARY=yq_linux_amd64
+bin/yq:
+	if [ ! -e bin ] ; then mkdir -p bin; fi
+	wget  https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O bin/${YQ_BINARY} && mv -f bin/${YQ_BINARY} bin/yq && chmod +x bin/yq

--- a/convert.sh
+++ b/convert.sh
@@ -4,6 +4,6 @@ set -eu -o pipefail
 out=$(cat $1)
 while IFS= read -r img; do
 	export rendered=$(bin/opm render "$img" -o yaml)
-	out=$(echo "$out" | ${YQ} "(select(.schema == \"olm.bundle\" and .image == \"$img\")) |= env(rendered)" -)
-done <<< $(echo "$out" | ${YQ} "select(.schema == \"olm.bundle\") | [.image][]" - | sed -e '/^---[ 	]*$/d')
+	out=$(echo "$out" | ${YQ} eval-all "(select(.schema == \"olm.bundle\" and .image == \"$img\")) |= env(rendered)" -)
+done <<< $(echo "$out" | ${YQ} eval-all "select(.schema == \"olm.bundle\") | [.image][]" -)
 echo "$out"

--- a/convert.sh
+++ b/convert.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+YQ=bin/yq
 set -eu -o pipefail
 out=$(cat $1)
 while IFS= read -r img; do
 	export rendered=$(bin/opm render "$img" -o yaml)
-	out=$(echo "$out" | yq eval-all "(select(.schema == \"olm.bundle\" and .image == \"$img\")) |= env(rendered)" -)
-done <<< $(echo "$out" | yq eval-all "select(.schema == \"olm.bundle\") | [.image][]" -)
+	out=$(echo "$out" | ${YQ} "(select(.schema == \"olm.bundle\" and .image == \"$img\")) |= env(rendered)" -)
+done <<< $(echo "$out" | ${YQ} "select(.schema == \"olm.bundle\") | [.image][]" -)
 echo "$out"

--- a/convert.sh
+++ b/convert.sh
@@ -5,5 +5,5 @@ out=$(cat $1)
 while IFS= read -r img; do
 	export rendered=$(bin/opm render "$img" -o yaml)
 	out=$(echo "$out" | ${YQ} "(select(.schema == \"olm.bundle\" and .image == \"$img\")) |= env(rendered)" -)
-done <<< $(echo "$out" | ${YQ} "select(.schema == \"olm.bundle\") | [.image][]" -)
+done <<< $(echo "$out" | ${YQ} "select(.schema == \"olm.bundle\") | [.image][]" - | sed -e '/^---[ 	]*$/d')
 echo "$out"


### PR DESCRIPTION
When I was working to integrate this to the demo workflow I ran into a couple of problems:
1 - I had an alias to `yq` to execute an arbitrary command in a docker container, which didn't work with pipelining commands via this script.  Since `yq` is still very much not a core tool, I thought I'd add Makefile rules to grab it similar to `opm`, which meant informing the script about the relative path; 
2 - When I ran the script and got the non-fatal error
```$ make
rm -rf catalog && mkdir catalog && ./convert.sh veneer.yaml > catalog/catalog.yaml
Error: bad flag syntax: ---
Usage:
  opm render [index-image | bundle-image | sqlite-file]... [flags]

Flags:
  -h, --help            help for render
  -o, --output string   Output format (json|yaml) (default "json")

Global Flags:
      --skip-tls   skip TLS certificate verification for container image registries while pulling bundles or index
```
Since I'm still not fully-conversant with all the interactions here, I presumed that this was environment drift, something I screwed up, actually fatal, etc.  so I dug into it and found ultimately that it's due to the fact that the yq filter that feeds the while loop wasn't excluding the new document marker `---` from the input list.  I added a sed filter to delete any resulting line from the input list which consists of the marker followed by any quantity or kind of whitespace, to the end of the line. 
